### PR TITLE
誤字を修正

### DIFF
--- a/day2/day2_01__mlflow.py
+++ b/day2/day2_01__mlflow.py
@@ -100,7 +100,7 @@ sales2018_DF = << FILL IN >>
 
 # COMMAND ----------
 
-# DBTITLE 1,temporaryテーブルの生成
+# DBTITLE 1,temporary view の作成
 # SQLで確認するために、一時テーブルの生成
 << FILL IN >>
 

--- a/day2/day2_01__mlflow.py
+++ b/day2/day2_01__mlflow.py
@@ -90,13 +90,9 @@ sales2018_DF = << FILL IN >>
 
 # COMMAND ----------
 
-# MAGIC %md ## Q3. temporary view の作成
+# MAGIC %md ## Q3. temporary viewの作成
 # MAGIC 
 # MAGIC SQLで確認するために、一時ビューの生成を行なってください
-# MAGIC 
-# MAGIC 参考リンク
-# MAGIC 
-# MAGIC - [一時ビューとは - Azure Databricks | Microsoft Learn](https://learn.microsoft.com/ja-jp/azure/databricks/lakehouse/data-objects#--what-is-a-temporary-view)
 
 # COMMAND ----------
 

--- a/day2/day2_01__mlflow.py
+++ b/day2/day2_01__mlflow.py
@@ -4,7 +4,7 @@
 # MAGIC ### 本ノートブックの目的：MLflowを使ったモデル開発について理解を深める
 # MAGIC Q1. ゴールドテーブルをロードする<br>
 # MAGIC Q2. データをfiltering<br>
-# MAGIC Q3. temporary tebleの作成<br>
+# MAGIC Q3. temporary view の作成<br>
 # MAGIC Q4. prophetのmodel作成<br>
 # MAGIC Q5. mlflowで管理
 # MAGIC 
@@ -18,14 +18,6 @@
 # MAGIC %md
 # MAGIC 
 # MAGIC 加工したデータを使って、売上データの予測を手動で行います
-
-# COMMAND ----------
-
-# MAGIC %md
-# MAGIC 作業中
-# MAGIC prophetインストールすると、DFが消えるのでcluster側に最初からinstall
-
-
 
 # COMMAND ----------
 
@@ -98,9 +90,13 @@ sales2018_DF = << FILL IN >>
 
 # COMMAND ----------
 
-# MAGIC %md ## Q3. temporary tebleの作成
+# MAGIC %md ## Q3. temporary view の作成
 # MAGIC 
-# MAGIC SQLで確認するために、一時テーブルの生成を行なってください
+# MAGIC SQLで確認するために、一時ビューの生成を行なってください
+# MAGIC 
+# MAGIC 参考リンク
+# MAGIC 
+# MAGIC - [一時ビューとは - Azure Databricks | Microsoft Learn](https://learn.microsoft.com/ja-jp/azure/databricks/lakehouse/data-objects#--what-is-a-temporary-view)
 
 # COMMAND ----------
 
@@ -163,7 +159,7 @@ pd_df_renamed = df_renamed.select("*").toPandas()
 # COMMAND ----------
 
 # DBTITLE 1,display()で確認
-display(pd_orderitem_joinDF)
+display(pd_df_renamed)
 
 # COMMAND ----------
 
@@ -258,7 +254,7 @@ from prophet.diagnostics import cross_validation, performance_metrics
 
 ARTIFACT_PATH = "model"
 experiment_name = f"/Users/{username_raw}/databricks_automl/project-olist-sales-forcast-2nd"
-mlflow.set_experiment(experiment_name)
+# mlflow.set_experiment(experiment_name)
 
 def extract_params(pr_model):
     return {attr: getattr(pr_model, attr) for attr in serialize.SIMPLE_ATTRIBUTES}
@@ -298,6 +294,7 @@ ml_flow_forecast = loaded_model.predict(loaded_model.make_future_dataframe(perio
 # COMMAND ----------
 
 #予測
+from prophet import plot
 plot.plot_plotly(model, ml_flow_forecast)
 
 # COMMAND ----------

--- a/day2_with_answers/day2_01__mlflow.py
+++ b/day2_with_answers/day2_01__mlflow.py
@@ -4,7 +4,7 @@
 # MAGIC ### 本ノートブックの目的：MLflowを使ったモデル開発について理解を深める
 # MAGIC Q1. ゴールドテーブルをロードする<br>
 # MAGIC Q2. データをfiltering<br>
-# MAGIC Q3. temporary tebleの作成<br>
+# MAGIC Q3. temporary view の作成<br>
 # MAGIC Q4. prophetのmodel作成<br>
 # MAGIC Q5. mlflowで管理
 # MAGIC 
@@ -17,13 +17,6 @@
 
 # MAGIC %md 
 # MAGIC 加工したデータを使って、売上データの予測を手動で行います
-
-# COMMAND ----------
-
-# MAGIC %md
-# MAGIC 作業中
-# MAGIC prophetインストールすると、DFが消えるのでcluster側に最初からinstall
-
 
 # COMMAND ----------
 
@@ -101,14 +94,18 @@ sales2018_DF = df_renamed \
 
 # COMMAND ----------
 
-# MAGIC %md ## Q3. temporary tebleの作成
+# MAGIC %md ## Q3. temporary viewの作成
 # MAGIC 
-# MAGIC SQLで確認するために、一時テーブルの生成を行なってください
+# MAGIC SQLで確認するために、一時ビューの生成を行なってください
+# MAGIC 
+# MAGIC 参考リンク
+# MAGIC 
+# MAGIC - [一時ビューとは - Azure Databricks | Microsoft Learn](https://learn.microsoft.com/ja-jp/azure/databricks/lakehouse/data-objects#--what-is-a-temporary-view)
 
 # COMMAND ----------
 
 # DBTITLE 1,Q3.Answer
-# SQLで確認するために、一時テーブルの生成
+# SQLで確認するために、一時ビューの生成
 sales2017_DF.createOrReplaceTempView("2017_sales")
 sales2018_DF.createOrReplaceTempView("2018_sales")
 
@@ -343,6 +340,7 @@ ml_flow_forecast = loaded_model.predict(loaded_model.make_future_dataframe(perio
 # COMMAND ----------
 
 #予測
+from prophet import plot
 plot.plot_plotly(model, ml_flow_forecast)
 
 # COMMAND ----------

--- a/day2_with_answers/day2_01__mlflow.py
+++ b/day2_with_answers/day2_01__mlflow.py
@@ -97,10 +97,6 @@ sales2018_DF = df_renamed \
 # MAGIC %md ## Q3. temporary viewの作成
 # MAGIC 
 # MAGIC SQLで確認するために、一時ビューの生成を行なってください
-# MAGIC 
-# MAGIC 参考リンク
-# MAGIC 
-# MAGIC - [一時ビューとは - Azure Databricks | Microsoft Learn](https://learn.microsoft.com/ja-jp/azure/databricks/lakehouse/data-objects#--what-is-a-temporary-view)
 
 # COMMAND ----------
 


### PR DESCRIPTION
下記を実施

> Q3. temporary tebleの作成
SQLで確認するために、一時テーブルの生成を行なってください
という表現が一時テーブルって何？一時Viewとどう違うの？という混乱を生んでしまいました。

 一時テーブル （temporary teble）となっていることを、一時ビュー（temporary view）ーに変更

> Cmd 23
問題：display(pd_df_renamed) であるべきところ、生徒用はdisplay(pd_orderitem_joinDF)になっていてエラーになる
対処：display(pd_df_renamed) に変更する

- day2_with_answers/day2_01__mlflow cmd 21 を修正
- day2/day2_01__mlflow cmd 21 を修正

> Cmd 30
問題：11 行目の「mlflow.set_experiment(experiment_name)」がエラーになる
対処：当該行をコメントアウト

- day2_with_answers/day2_01__mlflow cmd 29 を修正
- day2/day2_01__mlflow cmd 30 を修正

> Cmd 31
問題：「plot.plot_plotly(model, ml_flow_forecast)」がインポート文がないためエラーになる
対処：上記行の前に以下インポート文を追加 from fbprophet import plot

- day2_with_answers/day2_01__mlflow cmd 31 を修正
- day2/day2_01__mlflow cmd  30 を修正

> cmd 3 が不要となったため、削除

- day2_with_answers/day2_01__mlflow cmd 3 を削除
- day2/day2_01__mlflow cmd  3 を削除

#63